### PR TITLE
Revert "Merge branch 'feature/2' into release-1.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,6 @@ All notable changes to this project will be documented in this file, in reverse 
 
 Versions prior to 0.2.0 were released as the package "webimpress/zend-pimple-config".
 
-## 1.0.0alpha1 - TBD
-
-### Added
-
-- Nothing.
-
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- [#2](https://github.com/zendframework/zend-pimple-config/pull/2)
-  removes "extensions" support as these have the same functionality
-  as delegators.
-
-### Fixed
-
-- Nothing.
-
 ## 0.2.0 - 2017-11-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file, in reverse 
 
 Versions prior to 0.2.0 were released as the package "webimpress/zend-pimple-config".
 
+## 1.0.0alpha1 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 0.2.0 - 2017-11-21
 
 ### Added

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -121,6 +121,125 @@ class ConfigTest extends TestCase
         self::assertSame($myService, $this->container->offsetGet('alias'));
     }
 
+    public function testInjectExtensionForInvokable()
+    {
+        $dependencies = [
+            'invokables' => [
+                'foo-bar' => TestAsset\Service::class,
+            ],
+            'extensions' => [
+                'foo-bar' => [
+                    TestAsset\ExtensionFactory::class,
+                ],
+            ],
+        ];
+
+        (new Config(['dependencies' => $dependencies]))->configureContainer($this->container);
+
+        self::assertTrue($this->container->offsetExists('foo-bar'));
+        $service = $this->container->offsetGet('foo-bar');
+        self::assertInstanceOf(TestAsset\Extension::class, $service);
+        self::assertInstanceOf(TestAsset\Service::class, $service->service);
+        self::assertSame('foo-bar', $service->name);
+    }
+
+    public function testInjectExtensionForService()
+    {
+        $myService = new TestAsset\Service();
+        $dependencies = [
+            'services' => [
+                'foo-bar' => $myService,
+            ],
+            'extensions' => [
+                'foo-bar' => [
+                    TestAsset\ExtensionFactory::class,
+                ],
+            ],
+        ];
+
+        (new Config(['dependencies' => $dependencies]))->configureContainer($this->container);
+
+        self::assertTrue($this->container->offsetExists('foo-bar'));
+        $service = $this->container->offsetGet('foo-bar');
+        self::assertInstanceOf(TestAsset\Extension::class, $service);
+        self::assertSame($myService, $service->service);
+        self::assertSame('foo-bar', $service->name);
+    }
+
+    public function testInjectExtensionForFactory()
+    {
+        $dependencies = [
+            'factories' => [
+                'foo-bar' => TestAsset\Factory::class,
+            ],
+            'extensions' => [
+                'foo-bar' => [
+                    TestAsset\ExtensionFactory::class,
+                ],
+            ],
+        ];
+
+        (new Config(['dependencies' => $dependencies]))->configureContainer($this->container);
+
+        self::assertTrue($this->container->offsetExists('foo-bar'));
+        $service = $this->container->offsetGet('foo-bar');
+        self::assertInstanceOf(TestAsset\Extension::class, $service);
+        self::assertInstanceOf(TestAsset\Service::class, $service->service);
+        self::assertSame('foo-bar', $service->name);
+    }
+
+    public function testInjectMultipleExtensions()
+    {
+        $dependencies = [
+            'invokables' => [
+                'foo-bar' => TestAsset\Service::class,
+            ],
+            'extensions' => [
+                'foo-bar' => [
+                    TestAsset\Extension1Factory::class,
+                    TestAsset\Extension2Factory::class,
+                ],
+            ],
+        ];
+
+        (new Config(['dependencies' => $dependencies]))->configureContainer($this->container);
+
+        self::assertTrue($this->container->offsetExists('foo-bar'));
+        $service = $this->container->offsetGet('foo-bar');
+        self::assertInstanceOf(TestAsset\Service::class, $service);
+        self::assertEquals(
+            [
+                TestAsset\Extension1Factory::class,
+                TestAsset\Extension2Factory::class,
+            ],
+            $service->injected
+        );
+    }
+
+    public function testInjectMultipleExtensionsAsDecorators()
+    {
+        $myService = new TestAsset\Service();
+        $dependencies = [
+            'services' => [
+                'foo-bar' => $myService,
+            ],
+            'extensions' => [
+                'foo-bar' => [
+                    TestAsset\Decorator1Factory::class,
+                    TestAsset\Decorator2Factory::class,
+                ],
+            ],
+        ];
+
+        (new Config(['dependencies' => $dependencies]))->configureContainer($this->container);
+
+        self::assertTrue($this->container->offsetExists('foo-bar'));
+        $service = $this->container->offsetGet('foo-bar');
+        self::assertInstanceOf(TestAsset\Decorator2::class, $service);
+        self::assertInstanceOf(TestAsset\Decorator1::class, $service->originService);
+        self::assertSame($myService, $service->originService->originService);
+    }
+
     public function testInjectDelegatorForInvokable()
     {
         $dependencies = [


### PR DESCRIPTION
Revert #2 

@weierophinney said (https://github.com/zendframework/zend-pimple-config/pull/3#discussion_r156503536):
> I don't think we should likely remove this feature.
>
> We provide users a choice in terms of which container implementation they wish to use, and adapt certain features we feel should be common and work the same between implementations (invokables and delegators, primarily). However, people choose container implementations based on features they provide outside basic compatibility: speed, ease of configuration, extensibility, etc.
>
> Disabling this particular feature makes it harder for end-users to configure Pimple if they want to use Pimple-specific features. Yes, this feature largely replicates what delegators do; in point of fact, however, the way we implement delegators within Pimple is as extensions!
>
> Let's keep this feature, please.


