### PR TITLE
Ability to disable shared services with Pimple container

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ $factory = new ContainerFactory();
 $container = $factory(
     new Config([
         'dependencies' => [
-            'services'   => [],
-            'invokables' => [],
-            'factories'  => [],
-            'aliases'    => [],
-            'delegators' => [],
-            'extensions' => [],
+            'services'          => [],
+            'invokables'        => [],
+            'factories'         => [],
+            'aliases'           => [],
+            'delegators'        => [],
+            'extensions'        => [],
+            'shared'            => [],
+            'shared_by_default' => true,
         ],
         // ... other configuration
     ])
@@ -62,6 +64,11 @@ The `dependencies` sub associative array can contain the following keys:
   for more details.
 - `extensions`: an associative array that maps service names to lists of
   extension factory names, see the [the section below](#extensions).
+- `shared`: associative array that map a service name to a boolean, in order to
+  indicate the service manager if it should cache or not a service created
+  through the get method, independant of the shared_by_default setting.
+- `shared_by_default`: boolean that indicates whether services created through
+  the `get` method should be cached. This is `true` by default.
 
 > Please note, that the whole configuration is available in the `$container`
 > on `config` key:

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-pimple-config for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-pimple-config/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Pimple\Config;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Pimple\Config\Config;
+use Zend\Pimple\Config\ContainerFactory;
+
+class ContainerTest extends TestCase
+{
+    public function config()
+    {
+        yield 'factories' => [['factories' => ['service' => TestAsset\Factory::class]]];
+        yield 'invokables' => [['invokables' => ['service' => TestAsset\Service::class]]];
+        yield 'aliases-invokables' => [
+            [
+                'aliases' => ['service' => TestAsset\Service::class],
+                'invokables' => [TestAsset\Service::class => TestAsset\Service::class],
+            ],
+        ];
+        yield 'aliases-factories' => [
+            [
+                'aliases' => ['service' => TestAsset\Service::class],
+                'factories' => [TestAsset\Service::class => TestAsset\Factory::class],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider config
+     */
+    public function testIsSharedByDefault(array $config)
+    {
+        $container = $this->createContainer($config);
+
+        $service1 = $container->get('service');
+        $service2 = $container->get('service');
+
+        $this->assertSame($service1, $service2);
+    }
+
+    /**
+     * @dataProvider config
+     */
+    public function testCanDisableSharedByDefault(array $config)
+    {
+        $container = $this->createContainer(array_merge($config, [
+            'shared_by_default' => false,
+        ]));
+
+        $service1 = $container->get('service');
+        $service2 = $container->get('service');
+
+        $this->assertNotSame($service1, $service2);
+    }
+
+    /**
+     * @dataProvider config
+     */
+    public function testCanDisableSharedForSingleService(array $config)
+    {
+        $container = $this->createContainer(array_merge($config, [
+            'shared' => [
+                'service' => false,
+            ],
+        ]));
+
+        $service1 = $container->get('service');
+        $service2 = $container->get('service');
+
+        $this->assertNotSame($service1, $service2);
+    }
+
+    /**
+     * @dataProvider config
+     */
+    public function testCanEnableSharedForSingleService(array $config)
+    {
+        $container = $this->createContainer(array_merge($config, [
+            'shared_by_default' => false,
+            'shared' => [
+                'service' => true,
+            ],
+        ]));
+
+        $service1 = $container->get('service');
+        $service2 = $container->get('service');
+
+        $this->assertSame($service1, $service2);
+    }
+
+    private function createContainer(array $config)
+    {
+        $factory = new ContainerFactory();
+
+        return $factory(new Config(['dependencies' => $config]));
+    }
+}


### PR DESCRIPTION
By default all services created through the `get` method were shared, first call creates an instance, and every another call return the previously created instance.
Providing service name in "shared" allows to disable this functionality for a specific service. Then every call of the `get` method creates brand new instance of the service.
It is possoble to disable shared services by default for all services by using `shared_by_default` option to boolean `false`.

See:
- https://github.com/zendframework/zend-expressive/pull/543#discussion_r165378017
- https://github.com/zendframework/zend-servicemanager/pull/248