### PR TITLE
Fix invokable configuration when key is not provided and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The `dependencies` sub associative array can contain the following keys:
 - `services`: an associative array that maps a key to a specific service instance.
 - `invokables`: an associative array that map a key to a constructor-less
   service; i.e., for services that do not require arguments to the constructor.
-  The key and service name may be the same; if they are not, the key is treated
-  as an alias.
+  The key and service name usually are the same; if they are not, the key is
+  treated as an alias.
 - `factories`: an associative array that maps a service name to a factory class
   name, or any callable. Factory classes must be instantiable without arguments,
   and callable once instantiated (i.e., implement the `__invoke()` method).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The `dependencies` sub associative array can contain the following keys:
 - `services`: an associative array that maps a key to a specific service instance.
 - `invokables`: an associative array that map a key to a constructor-less
   service; i.e., for services that do not require arguments to the constructor.
-  The key and service name may be the same; if they are not, the name is treated
+  The key and service name may be the same; if they are not, the key is treated
   as an alias.
 - `factories`: an associative array that maps a service name to a factory class
   name, or any callable. Factory classes must be instantiable without arguments,

--- a/src/Config.php
+++ b/src/Config.php
@@ -83,11 +83,13 @@ class Config implements ConfigInterface
         }
 
         foreach ($dependencies['invokables'] as $name => $object) {
-            if (is_int($name)) {
-                $name = $object;
+            if ($name !== $object) {
+                $container[$name] = function (Container $c) use ($object) {
+                    return $c->offsetGet($object);
+                };
             }
 
-            $container[$name] = function (Container $c) use ($object) {
+            $container[$object] = function (Container $c) use ($object) {
                 return new $object();
             };
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -83,6 +83,10 @@ class Config implements ConfigInterface
         }
 
         foreach ($dependencies['invokables'] as $name => $object) {
+            if (is_int($name)) {
+                $name = $object;
+            }
+
             $container[$name] = function (Container $c) use ($object) {
                 return new $object();
             };

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -334,4 +334,19 @@ class ConfigTest extends TestCase
             $service->injected
         );
     }
+
+    public function testInvokablesWithoutAlias()
+    {
+        $dependencies = [
+            'invokables' => [
+                TestAsset\Service::class,
+            ],
+        ];
+
+        (new Config(['dependencies' => $dependencies]))->configureContainer($this->container);
+
+        self::assertTrue($this->container->offsetExists(TestAsset\Service::class));
+        $service = $this->container->offsetGet(TestAsset\Service::class);
+        self::assertInstanceOf(TestAsset\Service::class, $service);
+    }
 }

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -335,7 +335,7 @@ class ConfigTest extends TestCase
         );
     }
 
-    public function testInvokablesWithoutAlias()
+    public function testInvokableWithAlias()
     {
         $dependencies = [
             'invokables' => [
@@ -348,5 +348,25 @@ class ConfigTest extends TestCase
         self::assertTrue($this->container->offsetExists(TestAsset\Service::class));
         $service = $this->container->offsetGet(TestAsset\Service::class);
         self::assertInstanceOf(TestAsset\Service::class, $service);
+        self::assertTrue($this->container->offsetExists('0'));
+    }
+
+    public function testInvokableWithoutAlias()
+    {
+        $dependencies = [
+            'invokables' => [
+                'alias' => TestAsset\Service::class,
+            ],
+        ];
+
+        (new Config(['dependencies' => $dependencies]))->configureContainer($this->container);
+
+        self::assertTrue($this->container->offsetExists('alias'));
+        $service = $this->container->offsetGet('alias');
+        self::assertInstanceOf(TestAsset\Service::class, $service);
+        self::assertTrue($this->container->offsetExists(TestAsset\Service::class));
+        $originService = $this->container->offsetGet(TestAsset\Service::class);
+        self::assertInstanceOf(TestAsset\Service::class, $originService);
+        self::assertSame($service, $originService);
     }
 }

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -335,7 +335,7 @@ class ConfigTest extends TestCase
         );
     }
 
-    public function testInvokableWithAlias()
+    public function testInvokableWithoutAlias()
     {
         $dependencies = [
             'invokables' => [
@@ -351,7 +351,7 @@ class ConfigTest extends TestCase
         self::assertTrue($this->container->offsetExists('0'));
     }
 
-    public function testInvokableWithoutAlias()
+    public function testInvokableWithAlias()
     {
         $dependencies = [
             'invokables' => [


### PR DESCRIPTION
Fixed invokable configuration - if key is different than class name the key is used as an alias.